### PR TITLE
:dancers: Provide MySQL implementation

### DIFF
--- a/examples/mysql-project/.gitignore
+++ b/examples/mysql-project/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port

--- a/examples/mysql-project/LICENSE
+++ b/examples/mysql-project/LICENSE
@@ -1,0 +1,214 @@
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from
+a Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license
+agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+distribute and sublicense the Contribution of such Contributor, if any, and
+such derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under
+Licensed Patents to make, use, sell, offer to sell, import and otherwise
+transfer the Contribution of such Contributor, if any, in source code and
+object code form.  This patent license shall apply to the combination of the
+Contribution and the Program if, at the time the Contribution is added by the
+Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any
+other combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses
+to its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other
+intellectual property rights of any other entity. Each Contributor disclaims
+any liability to Recipient for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual property rights
+needed, if any. For example, if a third party patent license is required to
+allow Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright license
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties and
+conditions, express and implied, including warranties or conditions of title
+and non-infringement, and implied warranties or conditions of merchantability
+and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability for
+damages, including direct, indirect, special, incidental and consequential
+damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are offered
+by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable manner on
+or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a
+manner which does not create potential liability for other Contributors.
+Therefore, if a Contributor includes the Program in a commercial product
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor") against any
+losses, damages and costs (collectively "Losses") arising from claims,
+lawsuits and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program in
+a commercial product offering.  The obligations in this section do not apply
+to any claims or Losses relating to any actual or alleged intellectual
+property infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor tocontrol, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim
+at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all risks
+associated with its exercise of rights under this Agreement , including but
+not limited to the risks and costs of program errors, compliance with
+applicable laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and
+does not cure such failure in a reasonable period of time after becoming
+aware of such noncompliance. If all Recipient's rights under this Agreement
+terminate, Recipient agrees to cease use and distribution of the Program as
+soon as reasonably practicable. However, Recipient's obligations under this
+Agreement and any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of
+the Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel or otherwise. All
+rights in the Program not expressly granted under this Agreement are
+reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/examples/mysql-project/README.md
+++ b/examples/mysql-project/README.md
@@ -1,0 +1,14 @@
+# mysql-project
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2014 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/examples/mysql-project/dev/mysql_project/migrations.clj
+++ b/examples/mysql-project/dev/mysql_project/migrations.clj
@@ -1,0 +1,9 @@
+(ns mysql-project.migrations)
+
+(defn configure-tern []
+  {:db {:classname   "com.mysql.jdbc.Driver"
+        :subprotocol "mysql"
+        :database    "mysql_example_db"
+        :user        "root"
+        :port        "3306"
+        :password    ""}})

--- a/examples/mysql-project/doc/intro.md
+++ b/examples/mysql-project/doc/intro.md
@@ -1,0 +1,3 @@
+# Introduction to postgres-project
+
+TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/examples/mysql-project/migrations/20141102101737-create-cats.edn
+++ b/examples/mysql-project/migrations/20141102101737-create-cats.edn
@@ -1,0 +1,7 @@
+{:up
+ [{:create-table :cats
+   :columns [[:id   "INT"  "PRIMARY KEY"]
+             [:name "VARCHAR(255)" "NOT NULL"]
+             [:paws "INT"]]}]
+ :down
+ [{:drop-table :cats}]}

--- a/examples/mysql-project/migrations/20141102192946-add-columns-to-cats.edn
+++ b/examples/mysql-project/migrations/20141102192946-add-columns-to-cats.edn
@@ -1,0 +1,7 @@
+{:up
+ [{:alter-table :cats
+   :add-columns [[:favourite-food "VARCHAR(255)" "DEFAULT 'fish'"]
+                 [:favourite-toy  "VARCHAR(255)" "DEFAULT 'gun'"]]}]
+ :down
+ [{:alter-table :cats
+   :drop-columns [:favourite-food :favourite-toy]}]}

--- a/examples/mysql-project/migrations/20141102232626-drop-column-from-cat.edn
+++ b/examples/mysql-project/migrations/20141102232626-drop-column-from-cat.edn
@@ -1,0 +1,6 @@
+{:up
+ [{:alter-table :cats
+   :drop-columns [:favourite-food]}]
+ :down
+ [{:alter-table :cats
+   :add-columns [[:favourite-food "VARCHAR(255)" "DEFAULT 'fish'"]]}]}

--- a/examples/mysql-project/migrations/20141104091724-add-index-to-cat.edn
+++ b/examples/mysql-project/migrations/20141104091724-add-index-to-cat.edn
@@ -1,0 +1,9 @@
+{:up
+ [{:create-index :cat-name
+   :on :cats
+   :unique true
+   :columns [:name]}]
+
+ :down
+ [{:drop-index :cat-name
+   :on :cats}]}

--- a/examples/mysql-project/project.clj
+++ b/examples/mysql-project/project.clj
@@ -1,0 +1,13 @@
+(defproject mysql-project "0.1.0-SNAPSHOT"
+  :description "Example mysqlql project using Tern"
+  :url "http://github.com/rsslldnphy/tern"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :plugins [[tern "0.1.0-SNAPSHOT"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [mysql/mysql-connector-java "5.1.6"]]
+
+  :profiles {:dev {:source-paths ["dev"]}}
+
+  :tern {:init mysql-project.migrations/configure-tern
+         :migration-dir "migrations"})

--- a/examples/mysql-project/src/mysql_project/core.clj
+++ b/examples/mysql-project/src/mysql_project/core.clj
@@ -1,0 +1,1 @@
+(ns postgres-project.core)

--- a/examples/mysql-project/test/mysql_project/core_test.clj
+++ b/examples/mysql-project/test/mysql_project/core_test.clj
@@ -1,0 +1,3 @@
+(ns postgres-project.core-test
+  (:require [clojure.test :refer :all]
+            [postgres-project.core :refer :all]))

--- a/src/tern/implementations.clj
+++ b/src/tern/implementations.clj
@@ -1,11 +1,12 @@
 (ns tern.implementations
   (:require [tern.postgresql :as postgresql]
+            [tern.mysql      :as mysql]
             [tern.log        :as log]))
 
 (def ^{:doc "A map of available migrator implementations."
        :private true}
   constructor-store
-  (atom {:postgresql postgresql/->PostgresqlMigrator}))
+  (atom {:postgresql postgresql/->PostgresqlMigrator :mysql mysql/->MysqlMigrator}))
 
 (defn register!
   "Register a new tern implementation. This function

--- a/src/tern/mysql.clj
+++ b/src/tern/mysql.clj
@@ -1,0 +1,168 @@
+(ns tern.mysql
+  (:require [tern.db           :refer :all]
+            [tern.log          :as log]
+            [clojure.java.jdbc :as jdbc]
+            [clojure.string    :as s])
+  (:import [java.util Date]
+           [java.sql PreparedStatement Timestamp]))
+
+(def ^{:doc "Set of supported commands. Used in `generate-sql` dispatch."
+       :private true}
+  supported-commands
+  #{:create-table :drop-table :alter-table :create-index :drop-index})
+
+(defmulti generate-sql
+  (fn [c] (some supported-commands (keys c))))
+
+(defmethod generate-sql
+  :create-table
+  [{table :create-table columns :columns}]
+  (log/info " - Creating table" (log/highlight (name table)))
+  [(apply jdbc/create-table-ddl table columns)])
+
+(defmethod generate-sql
+  :drop-table
+  [{table :drop-table}]
+  (log/info " - Dropping table" (log/highlight (name table)))
+  [(jdbc/drop-table-ddl table)])
+
+(defmethod generate-sql
+  :alter-table
+  [{table :alter-table add-columns :add-columns drop-columns :drop-columns}]
+  (log/info " - Altering table" (log/highlight (name table)))
+  (let [additions
+        (for [[column & specs] add-columns]
+          (do (log/info "    * Adding column" (log/highlight (name column)))
+            (format "ALTER TABLE %s ADD COLUMN %s %s"
+                    (to-sql-name table)
+                    (to-sql-name column)
+                    (s/join " " specs))))
+        removals
+        (for [column drop-columns]
+          (do (log/info "    * Dropping column" (log/highlight (name column)))
+            (format "ALTER TABLE %s DROP COLUMN %s"
+                    (to-sql-name table)
+                    (to-sql-name column))))]
+    (concat removals additions)))
+
+(defmethod generate-sql
+  :create-index
+  [{index   :create-index
+    table   :on
+    columns :columns
+    unique  :unique}]
+  (log/info " - Creating" (when unique "unique") "index" (log/highlight (name index)) "on" (log/highlight (name table)))
+  [(format "CREATE %s INDEX %s ON %s (%s)"
+           (if unique "UNIQUE" "")
+           (to-sql-name index)
+           (to-sql-name table)
+           (s/join ", " (map to-sql-name columns)))])
+
+(defmethod generate-sql
+  :drop-index
+  [{index :drop-index table :on}]
+  (log/info " - Dropping index" (log/highlight (name index)))
+  [(format "DROP INDEX %s ON %s" (to-sql-name index) (to-sql-name table))])
+
+(defmethod generate-sql
+  :default
+  [command]
+  (log/error "Don't know how to process command:" (log/highlight (pr-str command)))
+  (System/exit 1))
+
+(defn- database-exists?
+  [db]
+  (jdbc/query
+    (db-spec db "mysql")
+    ["SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?" (:database db)]
+    :result-set-fn first))
+
+(defn- table-exists?
+  [db table]
+  (jdbc/query
+    (db-spec db)
+    ["SELECT 1 FROM information_schema.tables WHERE table_name = ?" table]
+    :result-set-fn first))
+
+(defn- create-database
+  [db]
+  (jdbc/db-do-commands
+    (db-spec db "mysql") false
+    (format "CREATE DATABASE %s" (:database db))))
+
+(defn- create-version-table
+  [db version-table]
+  (apply jdbc/db-do-commands
+         (db-spec db)
+         (generate-sql
+           {:create-table version-table
+            :columns [[:version "VARCHAR(14)" "NOT NULL"]
+                      [:created "TIMESTAMP"   "NOT NULL"]]})))
+
+(defn- psql-error-message
+  [e]
+  (s/replace (.getMessage e) #"^(FATAL|ERROR): " ""))
+
+(defn- batch-update-error-message
+  [e]
+  (s/replace (.getMessage (.getNextException e)) #"^(FATAL|ERROR): " ""))
+
+(defn- init-db!
+  [{:keys [db version-table]}]
+  (try
+    (when-not (database-exists? db)
+      (create-database db)
+      (log/info "Created database:" (:database db)))
+    (when-not (table-exists? db version-table)
+      (create-version-table db version-table)
+      (log/info "Created table:   " version-table))))
+
+(defn- get-version
+  [{:keys [db version-table]}]
+  (try
+    (jdbc/query
+      (db-spec db)
+      [(format "SELECT version FROM %s
+               ORDER BY created DESC
+               LIMIT 1" version-table)]
+      :row-fn :version
+      :result-set-fn first)))
+
+(defn- current-timestamp
+  []
+  (str "{ts '" (Timestamp. (.getTime (Date.))) "'}"))
+
+(defn- update-schema-version
+  [version-table version]
+  (format "INSERT INTO %s (version, created) VALUES (%s, %s)"
+          version-table version (current-timestamp)))
+
+(defn- run-migration!
+  [{:keys [db version-table]} version commands]
+  (when-not (vector? commands)
+    (log/error "Values for `up` and `down` must be vectors of commands"))
+  (try
+    (apply jdbc/db-do-commands
+           (db-spec db)
+           (conj (into [] (mapcat generate-sql commands))
+                 (update-schema-version version-table version)))))
+
+(defn- validate-commands
+  [commands]
+  (cond (and (vector? commands)
+             (every? map? commands)) commands
+        (map? commands) [vec commands]
+        nil nil
+        :else (do
+                (log/error "The values for `up` and `down` must be either a map or a vector of maps.")
+                (System/exit 1))))
+
+(defrecord MysqlMigrator
+  [config]
+  Migrator
+  (init[this]
+    (init-db! config))
+  (version [this]
+    (or (get-version config) "0"))
+  (migrate [this version commands]
+    (run-migration! config version (validate-commands commands))))


### PR DESCRIPTION
This commit adds MySQL Support to Tern. The implementation is based on
the Postgresql implementation in that it implements the Migrator
protocol.

Because MySQL is resoundingly terrible with Timestamps (second only
precision is basically useless), the entry in the schema migrations table
has been calculated in the code and inserted into the table by hand.

It would be nice to be able to use built in database functions for this
as you would in a more feature complete database engine.
